### PR TITLE
Исправил битую ссылку

### DIFF
--- a/ru/00_О_проекте.md
+++ b/ru/00_О_проекте.md
@@ -128,7 +128,7 @@ Content Cell  | Content Cell
 
 
 [1]: https://file.modx.pro
-[2]: https://github.com/bezumkin/Docs/issues/new
+[2]: https://github.com/bezumkin/Docs/
 [3]: http://ru.wikipedia.org/wiki/Markdown
 [4]: http://daux.io
 [5]: https://github.com/justinwalsh/daux.io/issues/


### PR DESCRIPTION
Ссылка https://github.com/bezumkin/Docs/issues/new оказалась битой, исправил на https://github.com/bezumkin/Docs/