### PR TITLE
Update 02_pdoFetch.md

### DIFF
--- a/en/01_Components/01_pdoTools/02_Classes/02_pdoFetch.md
+++ b/en/01_Components/01_pdoTools/02_Classes/02_pdoFetch.md
@@ -12,7 +12,7 @@ $resources = $pdo->getCollection('modResource', array(
     'parents' => '1,5,6,-9',
     'includeTVs' => 'tv1, tv2',
     'sortby' => 'id',
-    'sortby' => 'asc',
+    'sortdir' => 'asc',
     'limit' => 20,
 ));
 $tpl = '@INLINE <p>[[+id]] - [[+pagetitle]]</p>';


### PR DESCRIPTION
There is a typo on line #15 

The second `sortby` causes example to fail, it should be `sortdir`.

