### PR TITLE
docs(minishop3): документация v1.8.0-beta1

### DIFF
--- a/docs/components/minishop3/development/events/manager.md
+++ b/docs/components/minishop3/development/events/manager.md
@@ -111,6 +111,14 @@ switch ($modx->event->name) {
 }
 ```
 
+::: tip Plugin Registry
+Для добавления кастомных вкладок на страницы товара и заказа используйте Plugin Registry API:
+- [Интеграция вкладок товара](/components/minishop3/development/product-tabs-integration) — `MS3ProductTabsRegistry`
+- [Интеграция вкладок заказа](/components/minishop3/development/order-tabs-integration) — `MS3OrderTabsRegistry`
+
+Оба registry подключаются через это событие с проверкой `$page`.
+:::
+
 ---
 
 ## Расширение интерфейса ExtJS

--- a/docs/components/minishop3/development/index.md
+++ b/docs/components/minishop3/development/index.md
@@ -16,4 +16,5 @@ title: Разработка
 - [JavaScript API](javascript) — Headless API для SPA (Vue, React, Vanilla JS)
 - [Frontend JavaScript](frontend-js) — полная документация включая UI-слой
 - [Интеграция вкладок товара](product-tabs-integration) — добавление вкладок на страницу товара
+- [Интеграция вкладок заказа](order-tabs-integration) — добавление вкладок на страницу заказа
 - [Backend API](backend-api/) — программный интерфейс для работы с сущностями из PHP-кода (товары, заказы, опции, покупатели)

--- a/docs/components/minishop3/development/order-tabs-integration.md
+++ b/docs/components/minishop3/development/order-tabs-integration.md
@@ -1,0 +1,426 @@
+---
+title: Интеграция вкладок заказа
+description: Руководство по добавлению собственных вкладок на страницу заказа
+---
+
+# Интеграция вкладок заказа
+
+MiniShop3 предоставляет API для добавления собственных вкладок на страницу заказа в админке. Вы можете интегрировать как Vue компоненты, так и ExtJS панели.
+
+::: info Аналогичный API
+Для вкладок товара используйте [`MS3ProductTabsRegistry`](/components/minishop3/development/product-tabs-integration).
+:::
+
+## Архитектура
+
+Страница заказа — полностью Vue-приложение (в отличие от товара, где Vue встроен в ExtJS):
+
+```
+Vue OrderView (корневой компонент)
+├── Информация (position: 0)
+├── Товары (position: 1, скрыта при создании)
+├── Адрес (position: 2)
+├── История (position: 3, скрыта при создании)
+└── [Ваши вкладки] (position: 4+)
+```
+
+## Registry API
+
+Для регистрации вкладок используется глобальный объект `window.MS3OrderTabsRegistry`.
+
+### `register(tabConfig)`
+
+Регистрирует новую вкладку.
+
+**Параметры:**
+
+| Параметр | Тип | Обязательный | Описание |
+|----------|-----|--------------|----------|
+| `key` | string | Да | Уникальный идентификатор вкладки |
+| `title` | string | Да | Заголовок вкладки |
+| `type` | string | Нет | `'vue'` (по умолчанию) или `'extjs'` |
+| `component` | object/string | Для Vue | Vue компонент (SFC объект или имя) |
+| `xtype` | string | Для ExtJS | xtype ExtJS компонента |
+| `extConfig` | object | Нет | Дополнительная конфигурация для ExtJS |
+| `props` | object | Нет | Дополнительные props для Vue компонента |
+| `position` | number | Нет | Позиция вкладки (по умолчанию `100`) |
+| `hideOnCreate` | boolean | Нет | Скрыть при создании нового заказа |
+
+**Возвращает:** `boolean` — успешность регистрации.
+
+**Зарезервированные ключи:** `info`, `products`, `address`, `history` — использовать нельзя.
+
+### Данные, передаваемые в компонент
+
+Каждая плагин-вкладка автоматически получает:
+
+| Параметр | Тип | Описание |
+|----------|-----|----------|
+| `orderId` | number | ID заказа (0 при создании) |
+| `order` | object | Данные заказа |
+| `config` | object | Конфигурация ms3 (`ms3.config`) |
+| `isCreateMode` | boolean | Режим создания нового заказа |
+
+## Подключение через MODX плагин
+
+Вкладки регистрируются через событие `msOnManagerCustomCssJs` с проверкой `page === 'order'`:
+
+```php
+<?php
+/**
+ * Событие: msOnManagerCustomCssJs
+ */
+
+$page = $scriptProperties['page'] ?? '';
+if ($page !== 'order') {
+    return;
+}
+
+/** @var msManagerController $controller */
+$controller = $scriptProperties['controller'];
+
+// Подключаем скрипт с регистрацией вкладки
+$controller->addHtml('
+<script>
+// ... регистрация вкладки (см. примеры ниже)
+</script>
+');
+```
+
+::: warning Порядок загрузки
+Скрипт из `msOnManagerCustomCssJs` выполняется **до** загрузки Vue-модуля (`order.min.js`).
+В этот момент `MS3OrderTabsRegistry` ещё не существует — необходимо создать заглушку с очередью (см. примеры ниже). Vue-модуль при загрузке подхватит `pendingTabs` из заглушки.
+:::
+
+## Интеграция Vue компонента
+
+### Inline-компонент (простой вариант)
+
+Подходит для простых вкладок без сборки:
+
+```php
+<?php
+// Плагин MODX — событие: msOnManagerCustomCssJs
+
+$page = $scriptProperties['page'] ?? '';
+if ($page !== 'order') {
+    return;
+}
+
+$controller = $scriptProperties['controller'];
+
+$controller->addHtml('
+<script>
+(function() {
+    if (!window.MS3OrderTabsRegistry) {
+        window.MS3OrderTabsRegistry = {
+            pendingTabs: [],
+            register: function(c) { this.pendingTabs.push(c); return true; }
+        };
+    }
+
+    window.MS3OrderTabsRegistry.register({
+        key: "delivery-tracking",
+        title: "Отслеживание",
+        type: "vue",
+        component: {
+            props: ["orderId", "order", "config", "isCreateMode"],
+            template: "<div style=\"padding: 20px\">"
+                + "<h3>Отслеживание доставки</h3>"
+                + "<p>Заказ #{{ order?.num }}, ID: {{ orderId }}</p>"
+                + "</div>"
+        },
+        position: 5,
+        hideOnCreate: true
+    });
+})();
+</script>
+');
+```
+
+### SFC-компонент (рекомендуемый вариант)
+
+Для полноценных компонентов со сборкой через Vite/Webpack:
+
+**1. Создайте Vue компонент:**
+
+```vue
+<!-- my-addon/src/OrderTrackingTab.vue -->
+<template>
+  <div class="tracking-tab">
+    <h3>Отслеживание доставки</h3>
+    <p>Заказ #{{ order?.num }}</p>
+    <p>Статус: {{ trackingStatus }}</p>
+    <button @click="refreshTracking">Обновить</button>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const props = defineProps({
+  orderId: { type: Number, required: true },
+  order: { type: Object, default: null },
+  config: { type: Object, default: () => ({}) },
+  isCreateMode: { type: Boolean, default: false }
+})
+
+const trackingStatus = ref('Загрузка...')
+
+async function refreshTracking() {
+  // Ваша логика получения данных
+  const response = await fetch(`/api/tracking/${props.orderId}`)
+  const data = await response.json()
+  trackingStatus.value = data.status
+}
+
+onMounted(() => {
+  if (props.orderId) {
+    refreshTracking()
+  }
+})
+</script>
+```
+
+**2. Создайте entry point:**
+
+```javascript
+// my-addon/src/entries/order-tab.js
+import OrderTrackingTab from '../components/OrderTrackingTab.vue'
+
+;(function() {
+  if (!window.MS3OrderTabsRegistry) {
+    window.MS3OrderTabsRegistry = {
+      pendingTabs: [],
+      register: function(c) { this.pendingTabs.push(c); return true; }
+    }
+  }
+
+  window.MS3OrderTabsRegistry.register({
+    key: 'tracking',
+    title: 'Отслеживание',
+    type: 'vue',
+    component: OrderTrackingTab, // объект SFC, не строка
+    position: 5,
+    hideOnCreate: true
+  })
+})()
+```
+
+**3. Подключите в MODX плагине:**
+
+```php
+<?php
+// Событие: msOnManagerCustomCssJs
+
+$page = $scriptProperties['page'] ?? '';
+if ($page !== 'order') {
+    return;
+}
+
+$controller = $scriptProperties['controller'];
+$assetsUrl = MODX_ASSETS_URL . 'components/myaddon/';
+
+// ES-модуль со сборкой
+$controller->addHtml(
+    '<script type="module" src="' . $assetsUrl . 'js/order-tab.min.js"></script>'
+);
+```
+
+::: tip Реактивность
+Vue-вкладки получают **реактивные** props. При загрузке заказа, сохранении или редактировании — props обновляются автоматически. Ваш компонент может использовать `watch` и `computed` для реакции на изменения.
+:::
+
+## Интеграция ExtJS компонента
+
+### 1. Создайте ExtJS панель
+
+```javascript
+// assets/components/myaddon/js/mgr/delivery-panel.js
+Ext.define('MyAddon.panel.DeliveryInfo', {
+  extend: 'Ext.Panel',
+  xtype: 'myaddon-delivery-panel',
+
+  initComponent: function() {
+    // this.orderId, this.order, this.config, this.isCreateMode
+    // доступны из конфигурации
+    Ext.apply(this, {
+      border: false,
+      bodyStyle: 'padding: 15px',
+      html: '<h3>Информация о доставке</h3>'
+          + '<p>Заказ ID: ' + this.orderId + '</p>'
+    })
+
+    MyAddon.panel.DeliveryInfo.superclass.initComponent.call(this)
+  }
+})
+```
+
+### 2. Зарегистрируйте вкладку и подключите скрипты
+
+```php
+<?php
+// Плагин — событие: msOnManagerCustomCssJs
+
+$page = $scriptProperties['page'] ?? '';
+if ($page !== 'order') {
+    return;
+}
+
+$controller = $scriptProperties['controller'];
+$assetsUrl = MODX_ASSETS_URL . 'components/myaddon/';
+
+// Сначала панель
+$controller->addJavascript($assetsUrl . 'js/mgr/delivery-panel.js');
+
+// Затем регистрация
+$controller->addHtml('
+<script>
+(function() {
+    if (!window.MS3OrderTabsRegistry) {
+        window.MS3OrderTabsRegistry = {
+            pendingTabs: [],
+            register: function(c) { this.pendingTabs.push(c); return true; }
+        };
+    }
+
+    window.MS3OrderTabsRegistry.register({
+        key: "delivery-info",
+        title: "Доставка",
+        type: "extjs",
+        xtype: "myaddon-delivery-panel",
+        extConfig: {
+            customParam: "value"
+        },
+        position: 6,
+        hideOnCreate: true
+    });
+})();
+</script>
+');
+```
+
+::: warning Снимок данных
+ExtJS-вкладка создаётся **один раз** при первом переключении на неё. Значения `order`, `orderId`, `config`, `isCreateMode` — это снимок на момент создания. Если заказ будет сохранён или изменён, ExtJS-панель **не получит** обновлённые данные автоматически. Для обновления данных реализуйте собственную логику (polling, подписка на события).
+:::
+
+## Позиционирование вкладок
+
+Встроенные вкладки имеют фиксированные позиции:
+
+| Вкладка | Позиция | Скрыта при создании |
+|---------|---------|---------------------|
+| Информация | 0 | Нет |
+| Товары | 1 | Да |
+| Адрес | 2 | Нет |
+| История | 3 | Да |
+
+Рекомендуемые позиции для кастомных вкладок: **4–99**.
+
+Вкладки с одинаковой позицией сортируются в порядке регистрации.
+
+## Валидация
+
+Registry проверяет конфигурацию при регистрации:
+
+- `key` и `title` — обязательны
+- `key` не должен совпадать с зарезервированными (`info`, `products`, `address`, `history`)
+- `type: 'vue'` требует `component`
+- `type: 'extjs'` требует `xtype`
+- Дубликат `key` — регистрация отклоняется
+
+При ошибке `register()` возвращает `false` и выводит `console.error`.
+
+## Отладка
+
+```javascript
+// Состояние registry
+console.log(window.MS3OrderTabsRegistry)
+
+// Проверить: Vue замонтирован?
+console.log(window.MS3OrderTabsRegistry._mounted)
+
+// Экземпляр OrderView
+console.log(window.MS3OrderTabsRegistry._instance)
+
+// Очередь до маунта (должна быть пуста после загрузки)
+console.log(window.MS3OrderTabsRegistry.pendingTabs)
+```
+
+## Полный пример: плагин доставки
+
+```php
+<?php
+/**
+ * Плагин: Вкладка отслеживания доставки в заказе
+ * Событие: msOnManagerCustomCssJs
+ */
+
+$page = $scriptProperties['page'] ?? '';
+if ($page !== 'order') {
+    return;
+}
+
+$controller = $scriptProperties['controller'];
+$assetsUrl = MODX_ASSETS_URL . 'components/mydelivery/';
+
+// Конфигурация для JS
+$orderId = (int)($_GET['id'] ?? 0);
+$deliveryConfig = [
+    'apiUrl' => $assetsUrl . 'connector.php',
+    'orderId' => $orderId,
+    'apiKey' => $modx->getOption('mydelivery_api_key'),
+];
+
+// Передаём конфигурацию и регистрируем вкладку
+$controller->addHtml('
+<script>
+    window.MyDeliveryConfig = ' . json_encode($deliveryConfig) . ';
+
+    (function() {
+        if (!window.MS3OrderTabsRegistry) {
+            window.MS3OrderTabsRegistry = {
+                pendingTabs: [],
+                register: function(c) { this.pendingTabs.push(c); return true; }
+            };
+        }
+
+        window.MS3OrderTabsRegistry.register({
+            key: "delivery-tracking",
+            title: "' . $modx->lexicon('mydelivery_tab_title') . '",
+            type: "vue",
+            component: {
+                props: ["orderId", "order", "config", "isCreateMode"],
+                data: function() {
+                    return { status: "Загрузка...", tracking: null }
+                },
+                template: "<div style=\"padding: 20px\">"
+                    + "<h3>' . $modx->lexicon('mydelivery_tracking') . '</h3>"
+                    + "<p><b>Заказ:</b> #{{ order?.num }}</p>"
+                    + "<p><b>Статус:</b> {{ status }}</p>"
+                    + "<pre v-if=\"tracking\">{{ JSON.stringify(tracking, null, 2) }}</pre>"
+                    + "<button @click=\"refresh\">Обновить</button>"
+                    + "</div>",
+                methods: {
+                    refresh: function() {
+                        var self = this;
+                        var cfg = window.MyDeliveryConfig || {};
+                        fetch(cfg.apiUrl + "?action=track&order_id=" + this.orderId)
+                            .then(function(r) { return r.json() })
+                            .then(function(data) {
+                                self.status = data.status || "Неизвестно";
+                                self.tracking = data;
+                            });
+                    }
+                },
+                mounted: function() {
+                    if (this.orderId) this.refresh();
+                }
+            },
+            position: 5,
+            hideOnCreate: true
+        });
+    })();
+</script>
+');
+```

--- a/docs/components/minishop3/development/routing.md
+++ b/docs/components/minishop3/development/routing.md
@@ -26,11 +26,17 @@ core/components/minishop3/
 │   ├── routes/
 │   │   ├── manager.php                    # Системные роуты Manager API
 │   │   └── web.php                        # Системные роуты Web API
+│   ├── ms3.routes.d/
+│   │   ├── manager/example-addon.php.dist # Пример для аддонов (Manager)
+│   │   └── web/example-addon.php.dist     # Пример для аддонов (Web)
 │   └── routes_manager.custom.example.php  # Пример кастомных роутов
 
 core/config/
 ├── ms3_routes_manager.custom.php          # Кастомные Manager роуты
-└── ms3_routes_web.custom.php              # Кастомные Web роуты
+├── ms3_routes_web.custom.php              # Кастомные Web роуты
+└── ms3.routes.d/                          # Модульные роуты аддонов
+    ├── manager/                           # Manager API фрагменты
+    └── web/                               # Web API фрагменты
 ```
 
 ## Базовое использование
@@ -619,6 +625,148 @@ $router->group('/api/mgr/promocodes', function($router) use ($modx) {
     new AuthMiddleware($modx, 'mgr')
 ]);
 ```
+
+## Модульные роуты для аддонов (`ms3.routes.d`)
+
+Файлы `ms3_routes_*.custom.php` подходят для ручной кастомизации, но **не для аддонов** — если два компонента пишут в один файл, при установке/удалении возникают конфликты.
+
+Для сторонних компонентов предусмотрена директория `core/config/ms3.routes.d/` — каждый аддон создаёт свой файл, конфликтов нет.
+
+::: tip Аналогия
+Паттерн повторяет `ms3.services.d/` для [сервисов](/components/minishop3/development/services).
+:::
+
+### Структура
+
+```
+core/config/ms3.routes.d/
+├── web/                          # Роуты Web API (api.php)
+│   ├── 50-mydelivery.php
+│   └── 50-mypayment.php
+└── manager/                      # Роуты Manager API (connector)
+    ├── 50-mydelivery.php
+    └── 50-myadmin.php
+```
+
+Файлы загружаются в **алфавитном порядке**. Используйте числовой префикс для управления приоритетом (`01-`, `50-`, `99-`).
+
+### Порядок загрузки
+
+**Web API (`api.php`):**
+
+1. `config/routes/web.php` — системные роуты
+2. `core/config/ms3_routes_web.custom.php` — ручные кастомизации
+3. `core/config/ms3.routes.d/web/*.php` — аддоны
+4. `build()` диспетчера
+
+**Manager API (`connector.php` → `Processors\Api\Router`):**
+
+1. `config/routes/manager.php` — системные роуты
+2. `core/config/ms3_routes_manager.custom.php` — ручные кастомизации
+3. `core/config/ms3.routes.d/manager/*.php` — аддоны
+4. `build()` диспетчера
+
+Каждый следующий уровень может переопределять роуты предыдущего по ключу `METHOD:PATTERN`.
+
+### Пример: Web API роуты аддона доставки
+
+```php
+<?php
+// core/config/ms3.routes.d/web/50-mydelivery.php
+
+use MiniShop3\Router\Response;
+use MiniShop3\Middleware\TokenMiddleware;
+
+$router->group('/api/v1/delivery/mydelivery', function ($router) use ($modx) {
+
+    $router->post('/calculate', function (array $vars, \MODX\Revolution\modX $modx) {
+        $input = json_decode(file_get_contents('php://input'), true) ?: [];
+        $cost = MyDelivery::calculate($input['address'] ?? '', $input['weight'] ?? 0);
+        return Response::success(['cost' => $cost]);
+    });
+
+    $router->get('/points', function (array $vars, \MODX\Revolution\modX $modx) {
+        $city = $vars['city'] ?? '';
+        $points = MyDelivery::getPickupPoints($city);
+        return Response::success(['points' => $points]);
+    });
+
+}, [new TokenMiddleware($modx)]);
+```
+
+### Пример: Manager API роуты аддона
+
+```php
+<?php
+// core/config/ms3.routes.d/manager/50-mydelivery.php
+
+use MiniShop3\Router\Middleware\AuthMiddleware;
+use MiniShop3\Router\Response;
+
+$router->group('/api/mgr/mydelivery', function ($router) use ($modx) {
+
+    $router->get('/settings', function (array $vars, \MODX\Revolution\modX $modx) {
+        return Response::success([
+            'api_key' => $modx->getOption('mydelivery_api_key'),
+            'enabled' => (bool) $modx->getOption('mydelivery_enabled'),
+        ]);
+    });
+
+    $router->put('/settings', function (array $vars, \MODX\Revolution\modX $modx) {
+        $data = json_decode(file_get_contents('php://input'), true) ?: [];
+        // Сохранение настроек...
+        return Response::success(['saved' => true]);
+    });
+
+}, [new AuthMiddleware($modx, 'mgr')]);
+```
+
+### Установка и удаление
+
+В resolver аддона:
+
+```php
+<?php
+// resolver при установке
+$routesDir = MODX_CORE_PATH . 'config/ms3.routes.d/';
+
+// Копируем файл роутов
+copy(
+    $source . 'routes/web.php',
+    $routesDir . 'web/50-mydelivery.php'
+);
+copy(
+    $source . 'routes/manager.php',
+    $routesDir . 'manager/50-mydelivery.php'
+);
+```
+
+```php
+<?php
+// resolver при удалении
+@unlink(MODX_CORE_PATH . 'config/ms3.routes.d/web/50-mydelivery.php');
+@unlink(MODX_CORE_PATH . 'config/ms3.routes.d/manager/50-mydelivery.php');
+```
+
+Каждый аддон удаляет только свой файл — другие аддоны не затрагиваются.
+
+### Обработка ошибок
+
+Если файл роутов содержит синтаксическую ошибку или выбрасывает исключение, он логируется и пропускается — **остальные файлы загружаются нормально**:
+
+```
+[MiniShop3 Router] Failed to load routes file /path/to/50-broken.php: syntax error...
+```
+
+### Custom-файл vs ms3.routes.d
+
+| | `ms3_routes_*.custom.php` | `ms3.routes.d/` |
+|---|---|---|
+| **Для кого** | Разработчик сайта | Авторы аддонов |
+| **Файлов** | Один на тип API | По файлу на аддон |
+| **Конфликты** | Возможны при нескольких аддонах | Нет |
+| **Install/uninstall** | Нужно редактировать вручную | Атомарный: создать/удалить файл |
+| **Создаётся** | При установке ms3 (example) | Аддон через resolver |
 
 ## Системные настройки
 


### PR DESCRIPTION
## Summary

Документация для MiniShop3 v1.8.0-beta1.

- **Новая статья:** [Интеграция вкладок заказа](docs/components/minishop3/development/order-tabs-integration.md) — `MS3OrderTabsRegistry` API для кастомных Vue/ExtJS вкладок на странице заказа (#166, #167)
- **Обновлён routing.md:** секция «Модульные роуты для аддонов» — `core/config/ms3.routes.d/`, примеры web/manager фрагментов, resolver, сравнение с custom-файлами (#169, #171)
- **Обновлён events/manager.md:** ссылки на Plugin Registry (order + product tabs) в секции `msOnManagerCustomCssJs`
- **Обновлён development/index.md:** ссылка на новую статью

## Test plan

- [ ] Проверить рендеринг новой статьи `order-tabs-integration.md`
- [ ] Проверить ссылки между страницами
- [ ] Проверить блоки кода (PHP, JavaScript, Vue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)