### PR TITLE
chore: sync bun.lock with package.json (uuid 14) and bump engines.node to >=20

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@vueuse/core": "^14.2.1",
         "@xobotyi/scrollbar-width": "^1.9.5",
         "glightbox": "^3.3.1",
-        "uuid": "^13.0.0",
+        "uuid": "^14.0.0",
       },
       "devDependencies": {
         "@cspell/dict-ru_ru": "^2.3.2",
@@ -1238,7 +1238,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
+    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "v8flags": ["v8flags@4.0.1", "", {}, "sha512-fcRLaS4H/hrZk9hYwbdRM35D0U8IYMfEClhXxCivOojl+yTRAZH3Zy2sSy6qVCiGbV9YAtPssP6jaChqC9vPCg=="],
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "uuid": "^14.0.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "packageManager": "pnpm@9.15.2+sha512.93e57b0126f0df74ce6bff29680394c0ba54ec47246b9cf321f0121d8d9bb03f750a705f24edc3c1180853afd7c2c3b94196d0a3d53d3e069d9e2793ef11f321"
 }


### PR DESCRIPTION
## Что сломалось

После мержа #889 (Dependabot bump uuid 13 → 14) сборка на CI упала:

```
Run bun install --frozen-lockfile
error: lockfile had changes, but lockfile is frozen
note: try re-running without --frozen-lockfile and commit the updated lockfile
Error: Process completed with exit code 1.
```

## Почему

В репо живут **два lockfile** для двух разных пакетных менеджеров:

- `pnpm-lock.yaml` — `package.json` объявляет `packageManager: pnpm@9.15.2`.
- `bun.lock` — а CI (`.github/workflows/deploy.yml`) собирает через **bun**: `bun install --frozen-lockfile` → `bun run build`.

Dependabot нативно умеет в pnpm/npm/yarn, но не в bun. PR #889 обновил `package.json` (`uuid: ^14`) и `pnpm-lock.yaml`, а `bun.lock` остался на `uuid@13.0.0`. CI с `--frozen-lockfile` упал на расхождении.

## Что в этом PR

1. **`bun.lock` пересобран** через `bun install` — теперь `uuid@14.0.0` в обеих позициях (`package.json`-блок и runtime-запись).
2. **`engines.node: ">=18"` → `">=20"`** в `package.json`. uuid 14 формально требует Node 20+ (drop Node 18, ожидает глобальный `crypto`). CI уже на Node 20 (`actions/setup-node@v4` + `node-version: '20'`), это просто синхронизация декларации с реальностью — чтобы `pnpm install` не молча проходил на Node 18, где uuid 14 в рантайме не заработает.

Итого 2 файла, +3/−3 строки.

## Проверено

```
$ bun install --frozen-lockfile
Checked 679 installs across 675 packages (no changes)
```

То есть на следующем CI build не упадёт.

## Что вне scope этого PR

Коренная проблема — **два lockfile + Dependabot обновляет только pnpm-lock**. Этот PR лечит симптом, не причину. Каждый следующий dep-bump от Dependabot снова будет ронять `bun install --frozen-lockfile` ровно по тому же сценарию.

Долгосрочное решение — выбрать один пакетный менеджер. Логичный кандидат — **pnpm**, потому что:

- `package.json` уже объявляет `packageManager: pnpm@9.15.2`,
- Dependabot его поддерживает «из коробки»,
- bun-конфигурацию для Dependabot официально пока нельзя задать.

Конкретно потребуется:
- удалить `bun.lock`,
- в `.github/workflows/deploy.yml` заменить `oven-sh/setup-bun@v2` + `bun install` + `bun run build` на `pnpm/action-setup@v4` + `pnpm install --frozen-lockfile` + `pnpm run build`.

Готов оформить отдельным PR, если согласны с этим направлением.

## Test plan

- [ ] CI после мержа этого PR проходит — `bun install --frozen-lockfile` возвращает `no changes`.
- [ ] Билд `vitepress build` отрабатывает без ошибок.
- [ ] Запустить локально на Node 20: `bun install && bun run build` — успех.