### PR TITLE
docs(ms3): sync with MiniShop3 1.12.0-beta1

### DIFF
--- a/docs/components/minishop3/development/events/notifications.md
+++ b/docs/components/minishop3/development/events/notifications.md
@@ -172,9 +172,32 @@ switch ($modx->event->name) {
 | Параметр | Тип | Описание |
 |----------|-----|----------|
 | `notification` | `NotificationInterface` | Объект уведомления |
-| `recipient` | `array` | Данные получателя |
+| `recipient` | `array` | Данные получателя — см. структуру ниже |
 | `recipientType` | `string` | Тип получателя: `customer` или `manager` |
 | `channels` | `string[]` | Список каналов отправки (например, `['email', 'telegram']`) |
+
+### Структура `recipient`
+
+Для **customer** (начиная с MiniShop3 1.12.0) `recipient` собирается в `OrderStatusService::getCustomerRecipient()` со следующим приоритетом источников:
+
+1. **`msOrderAddress`** заказа — email/phone из формы оформления **именно этого** заказа.
+2. **`msCustomer`** — fallback по email/phone + источник для `telegram_chat_id` и payload `customer`.
+3. **`modUserProfile`** — последний fallback для email/phone/telegram, когда первые два пусты.
+
+Резолвленные `email`/`phone` дополнительно зеркалятся в `recipient['customer']['email']`/`['phone']` для плагинов, читающих контакт оттуда.
+
+| Ключ | Тип | Источник | Описание |
+|------|-----|----------|----------|
+| `type` | `string` | — | `customer` или `manager` (дублирует `recipientType`) |
+| `email` | `string\|null` | address → customer → profile | Резолвленный email получателя |
+| `phone` | `string\|null` | address → customer → profile | Резолвленный телефон |
+| `telegram_chat_id` | `string\|null` | `customer.extended` → profile | ID чата Telegram, если задан |
+| `address` | `array` | `msOrderAddress->toArray()` | Полный адрес заказа (доступен только для customer-получателя) |
+| `customer` | `array` | `msCustomer->toArray()` | Объект клиента (доступен только для customer-получателя); поля `email`/`phone` уже синхронизированы с резолвленными значениями |
+
+:::tip Зачем разделять адрес и клиента
+До 1.12.0 уведомления слались по контактам из `msCustomer`, которые могли отличаться от контактов конкретного заказа (например, если в одной сессии оформили два заказа с разными email — оба уходили на email из msCustomer). См. [issue #218](https://github.com/modx-pro/MiniShop3/issues/218) / [PR #320](https://github.com/modx-pro/MiniShop3/pull/320).
+:::
 
 ### Прерывание операции
 
@@ -241,7 +264,7 @@ switch ($modx->event->name) {
 | Параметр | Тип | Описание |
 |----------|-----|----------|
 | `notification` | `NotificationInterface` | Объект уведомления |
-| `recipient` | `array` | Данные получателя |
+| `recipient` | `array` | Данные получателя — см. [структуру recipient](#структура-recipient) выше |
 | `recipientType` | `string` | Тип получателя: `customer` или `manager` |
 | `results` | `array<string,bool>` | Результат отправки по каналам, например `['email' => true, 'telegram' => false]` |
 

--- a/docs/components/minishop3/development/routing.md
+++ b/docs/components/minishop3/development/routing.md
@@ -417,6 +417,57 @@ $router->get('/api/mgr/endpoint', $handler, [
 | GET | `/sections/{page_key}` | Получить секции |
 | PUT | `/sections/{page_key}` | Обновить секции |
 
+#### Конфигурация гридов (`/grid-config`)
+
+CRUD для конфига колонок административных гридов. Все запросы требуют право `mssetting_save`.
+
+| Метод | Роут | Описание |
+|-------|------|----------|
+| GET | `/{grid_key}` | Получить конфигурацию грида |
+| PUT | `/{grid_key}` | Обновить конфигурацию грида |
+| POST | `/{grid_key}/field` | Добавить колонку |
+| PUT | `/{grid_key}/field/{field_name}` | Обновить колонку |
+| DELETE | `/{grid_key}/field/{field_name}` | Удалить колонку |
+
+**Известные `grid_key`:** `orders`, `customers`, `vendors`, `deliveries`, `payments`, `category-products`, `extra-fields`, `model-fields`, `notifications`, `option-groups`.
+
+##### Ответ `GET /grid-config/{grid_key}`
+
+```json
+{
+  "columns": [
+    { "name": "id", "label": "ID", "type": "model", "visible": true, ... }
+  ],
+  "direct_filter_keys": ["query", "status_id", "delivery_id", ...],
+  "editor_references": [
+    { "key": "vendors", "path": "/api/mgr/references/vendors" }
+  ]
+}
+```
+
+| Поле | Тип | Описание |
+|------|-----|----------|
+| `columns` | `array` | Колонки грида с конфигурацией (тип, видимость, фильтрация, редактор) |
+| `direct_filter_keys` | `string[]` | Ключи фильтров, которые контроллер ждёт как **прямые** параметры запроса (без префикса `filter_`). Остальные — отправлять с префиксом. Источник истины — backend; фронт читает массив отсюда. Появилось в MiniShop3 1.12.0 ([PR #317](https://github.com/modx-pro/MiniShop3/pull/317)) — закрывает дублирование между фронтом и контроллерами. |
+| `editor_references` | `array<{key,path}>` | **Только для `grid_key=category-products`.** Whitelist допустимых reference-ключей для combo-редактора inline-edit. Каждая запись — пара ключа и пути к API-эндпойнту справочника. Используется UI настройки колонок для select dropdown. Появилось в MiniShop3 1.12.0 ([PR #157](https://github.com/modx-pro/MiniShop3/pull/157)). |
+
+##### Контракт фильтров (`direct_filter_keys`)
+
+Фронт-код решает, как сериализовать значение фильтра:
+
+```js
+// Псевдокод composable useGridFilterParams
+function addFilterParam(params, key, value) {
+    if (directFilterKeys.has(key)) {
+        params[key] = value         // direct: ?status_id=2
+    } else {
+        params['filter_' + key] = value   // prefixed: ?filter_customer_name=...
+    }
+}
+```
+
+Это значит — добавляя новый прямой фильтр на бекенде, **обязательно** дописать его ключ в `DIRECT_FILTER_KEYS`-константу соответствующего контроллера. Иначе фронт отправит его с префиксом и фильтрация не сработает.
+
 #### Заказы (`/orders`)
 
 | Метод | Роут | Описание | Право |


### PR DESCRIPTION
## Описание

Sync документации с кодом MiniShop3 перед релизом **1.12.0-beta1**. Найдено через release-docs-sync audit.

## Изменения

### `events/notifications.md`

Обновлена структура параметра `recipient` для событий **`msOnBeforeSendNotification`** и **`msOnAfterSendNotification`**.

Начиная с 1.12.0 (PR [modx-pro/MiniShop3#320](https://github.com/modx-pro/MiniShop3/pull/320)) `OrderStatusService::getCustomerRecipient()` собирает customer-recipient в следующем порядке источников:

1. `msOrderAddress` — email/phone из формы оформления этого заказа.
2. `msCustomer` — fallback по email/phone + `telegram_chat_id` и payload `customer`.
3. `modUserProfile` — последний fallback.

Добавлена подтаблица с ключами `email`, `phone`, `telegram_chat_id`, `address`, `customer`, `type` и пояснение зеркалирования резолвленного email/phone обратно в `recipient['customer']` для backward compat.

Закрывает [issue #218](https://github.com/modx-pro/MiniShop3/issues/218).

### `routing.md`

Добавлен раздел **«Конфигурация гридов (`/grid-config`)»** — раньше эта группа роутов в доку не попадала вообще.

Покрыто:
- GET / PUT / POST field / PUT field / DELETE field — CRUD грид-конфига.
- Список известных `grid_key`.
- Структура ответа `GET /grid-config/{grid_key}` с тремя ключами:
  - `columns` — конфиг колонок.
  - `direct_filter_keys` — массив unprefixed-ключей фильтров (PR [#317](https://github.com/modx-pro/MiniShop3/pull/317), 1.12.0).
  - `editor_references` — whitelist combo-эдитора для `category-products` (PR [#157](https://github.com/modx-pro/MiniShop3/pull/157), 1.12.0).
- Контракт фронт-фильтрации (composable `useGridFilterParams`) с напоминанием контрибьюторам: добавляя прямой фильтр на бекенде — дописывать в `DIRECT_FILTER_KEYS`.

## Что НЕ вошло (follow-up)

Audit нашёл preexisting docs gaps, отложенные до отдельного PR:

- `settings.md` — 5 удалений ключей которых нет в коде, дефолт `ms3_order_show_drafts`, расхождения `ms3_status_*`, `ms3_telegram_manager`.
- `models.md` — `repeater_config` в `ms3_extra_fields`, `option_group_id` в `ms3_options`.
- `routing.md` — задокументировано только ~7 из ~20 групп manager-роутов (отсутствуют `/references`, `/options`, `/option-groups`, `/extra-fields`, `/model-fields`, `/product-data`, `/categories/{id}/products`, утилиты, finalize/recalculate-cost для orders).
- Скриншоты в `interface/*.md` — затронуто 15 Vue-компонентов в релизе, требуется ручная сверка.

Эти расхождения **не введены в 1.12.0-beta1**, накопились в прошлых релизах. Стоят отдельной задачи — можем закрыть либо после релиза, либо как issue в этом репо.

## Связанные релизные PR

- [feat(grid): option columns (#154)](https://github.com/modx-pro/MiniShop3/pull/154)
- [feat(grid): select/combo inline-edit (#157)](https://github.com/modx-pro/MiniShop3/pull/157)
- [feat(extra-fields): repeater field (#301)](https://github.com/modx-pro/MiniShop3/pull/301)
- [refactor(manager): direct_filter_keys (#317)](https://github.com/modx-pro/MiniShop3/pull/317)
- [fix(order): notification email (#320)](https://github.com/modx-pro/MiniShop3/pull/320)
