### PR TITLE
docs(reactions): Sync docs with Reactions 1.0.1

### DIFF
--- a/docs/components/reactions/integrations/collections.md
+++ b/docs/components/reactions/integrations/collections.md
@@ -55,7 +55,7 @@ title: Интеграция с Collections
 [[!pdoResources?
     &parents=`[[*id]]`
     &depth=`1`
-    &leftJoin=`{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
+    &leftJoin=`{"Aggregate":{"class":"Reactions\\\\Model\\\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
     &sortby=`Aggregate.likes`
     &sortdir=`DESC`
     &tpl=`@INLINE <li><a href="[[+uri]]">[[+pagetitle]]</a> — [[!ReactionsCount? &object=`[[+id]]` &format=`{LIKES}`]]</li>`
@@ -66,7 +66,12 @@ title: Интеграция с Collections
 {'!pdoResources' | snippet : [
     'parents' => $_modx->resource.id,
     'depth' => 1,
-    'leftJoin' => '{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = \'modResource\'"}}',
+    'leftJoin' => [
+        'Aggregate' => [
+            'class' => 'Reactions\Model\ReactionAggregate',
+            'on' => "Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'",
+        ],
+    ],
     'sortby' => 'Aggregate.likes',
     'sortdir' => 'DESC',
     'tpl' => '@INLINE <li><a href="[[+uri]]">[[+pagetitle]]</a> — [[!ReactionsCount? &object=`[[+id]]` &format=`{LIKES}`]]</li>',
@@ -116,7 +121,7 @@ title: Интеграция с Collections
 [[!pdoResources?
     &parents=`[[*id]]`
     &depth=`2`
-    &leftJoin=`{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
+    &leftJoin=`{"Aggregate":{"class":"Reactions\\\\Model\\\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
     &sortby=`Aggregate.trending_score`
     &sortdir=`DESC`
     &limit=`6`
@@ -129,7 +134,12 @@ title: Интеграция с Collections
 {'!pdoResources' | snippet : [
     'parents' => $_modx->resource.id,
     'depth' => 2,
-    'leftJoin' => '{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = \'modResource\'"}}',
+    'leftJoin' => [
+        'Aggregate' => [
+            'class' => 'Reactions\Model\ReactionAggregate',
+            'on' => "Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'",
+        ],
+    ],
     'sortby' => 'Aggregate.trending_score',
     'sortdir' => 'DESC',
     'limit' => 6,

--- a/docs/components/reactions/integrations/minishop3.md
+++ b/docs/components/reactions/integrations/minishop3.md
@@ -79,7 +79,7 @@ title: Интеграция с miniShop3
 
 ## Сортировка каталога по популярности
 
-Через `msProducts` и `leftJoin`.
+Через `msProducts` и `leftJoin`. Из‑за `GROUP BY msProduct.id` в msProducts используйте `MAX(Aggregate.likes)`, не `Aggregate.likes` (см. [pdoTools](pdotools)).
 
 ::: code-group
 
@@ -87,19 +87,25 @@ title: Интеграция с miniShop3
 [[!msProducts?
     &parents=`10`
     &limit=`12`
-    &leftJoin=`{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = msProduct.id AND Aggregate.object_class = 'msProduct'"}}`
-    &sortby=`Aggregate.likes`
+    &leftJoin=`{"Aggregate":{"class":"Reactions\\\\Model\\\\ReactionAggregate","on":"Aggregate.object_id = msProduct.id AND Aggregate.object_class = 'msProduct'"}}`
+    &sortby=`MAX(Aggregate.likes)`
     &sortdir=`DESC`
     &tpl=`tpl.msProduct.card`
 ]]
 ```
 
 ```fenom
+{set $rxProductJoin = [
+    'Aggregate' => [
+        'class' => 'Reactions\Model\ReactionAggregate',
+        'on' => "Aggregate.object_id = msProduct.id AND Aggregate.object_class = 'msProduct'",
+    ],
+]}
 {'!msProducts' | snippet : [
     'parents' => 10,
     'limit' => 12,
-    'leftJoin' => '{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = msProduct.id AND Aggregate.object_class = \'msProduct\'"}}',
-    'sortby' => 'Aggregate.likes',
+    'leftJoin' => $rxProductJoin,
+    'sortby' => 'MAX(Aggregate.likes)',
     'sortdir' => 'DESC',
     'tpl' => 'tpl.msProduct.card',
 ]}

--- a/docs/components/reactions/integrations/pdotools.md
+++ b/docs/components/reactions/integrations/pdotools.md
@@ -5,6 +5,28 @@ title: Интеграция с pdoTools
 
 Сортировка и вывод ресурсов, товаров и других объектов по реакциям через `leftJoin` на модель `ReactionAggregate`.
 
+## leftJoin: JSON и Fenom
+
+`leftJoin` передаётся в pdoTools как **массив** или JSON-строка. Класс модели в JSON пишется с экранированием: `"Reactions\\Model\\ReactionAggregate"` (в итоговой строке два символа `\` перед `Model`).
+
+| Способ | Пример |
+| --- | --- |
+| MODX-тег | `"class":"Reactions\\\\Model\\\\ReactionAggregate"` — **четыре** `\` в шаблоне, в JSON остаётся два |
+| Fenom | массив `'class' => 'Reactions\Model\ReactionAggregate'` — предпочтительно, без JSON |
+| PHP / сниппет | `'class' => ReactionAggregate::class` или массив join |
+
+Если JSON невалиден, `json_decode` в msProducts/pdoResources молча не добавит join. Тогда в логе:
+
+`Unknown column 'Aggregate.likes' in 'order clause'`
+
+### msProducts и ONLY_FULL_GROUP_BY
+
+`msProducts` всегда группирует по `msProduct.id`. На MySQL с `ONLY_FULL_GROUP_BY` нельзя сортировать просто по `Aggregate.likes` — используйте агрегат:
+
+`&sortby=`MAX(Aggregate.likes)`` или `'sortby' => 'MAX(Aggregate.likes)'`
+
+Для `pdoResources` без `GROUP BY` достаточно `Aggregate.likes`.
+
 ## Модель ReactionAggregate
 
 Таблица `reactions_aggregates` хранит предрассчитанные метрики:
@@ -30,7 +52,7 @@ title: Интеграция с pdoTools
     &parents=`0`
     &depth=`10`
     &limit=`12`
-    &leftJoin=`{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource' AND Aggregate.context = 'web'"}}`
+    &leftJoin=`{"Aggregate":{"class":"Reactions\\\\Model\\\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource' AND Aggregate.context = 'web'"}}`
     &sortby=`Aggregate.likes`
     &sortdir=`DESC`
     &tpl=`tpl.article.card`
@@ -42,7 +64,12 @@ title: Интеграция с pdoTools
     'parents' => 0,
     'depth' => 10,
     'limit' => 12,
-    'leftJoin' => '{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = \'modResource\' AND Aggregate.context = \'web\'"}}',
+    'leftJoin' => [
+        'Aggregate' => [
+            'class' => 'Reactions\Model\ReactionAggregate',
+            'on' => "Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource' AND Aggregate.context = 'web'",
+        ],
+    ],
     'sortby' => 'Aggregate.likes',
     'sortdir' => 'DESC',
     'tpl' => 'tpl.article.card',
@@ -58,7 +85,7 @@ title: Интеграция с pdoTools
 ```modx
 [[!pdoResources?
     &parents=`5`
-    &leftJoin=`{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
+    &leftJoin=`{"Aggregate":{"class":"Reactions\\\\Model\\\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
     &sortby=`Aggregate.rating`
     &sortdir=`DESC`
     &limit=`10`
@@ -68,7 +95,12 @@ title: Интеграция с pdoTools
 ```fenom
 {'!pdoResources' | snippet : [
     'parents' => 5,
-    'leftJoin' => '{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = \'modResource\'"}}',
+    'leftJoin' => [
+        'Aggregate' => [
+            'class' => 'Reactions\Model\ReactionAggregate',
+            'on' => "Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'",
+        ],
+    ],
     'sortby' => 'Aggregate.rating',
     'sortdir' => 'DESC',
     'limit' => 10,
@@ -84,7 +116,7 @@ title: Интеграция с pdoTools
 ```modx
 [[!pdoResources?
     &parents=`0`
-    &leftJoin=`{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
+    &leftJoin=`{"Aggregate":{"class":"Reactions\\\\Model\\\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
     &sortby=`Aggregate.trending_score`
     &sortdir=`DESC`
     &limit=`8`
@@ -94,7 +126,12 @@ title: Интеграция с pdoTools
 ```fenom
 {'!pdoResources' | snippet : [
     'parents' => 0,
-    'leftJoin' => '{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = \'modResource\'"}}',
+    'leftJoin' => [
+        'Aggregate' => [
+            'class' => 'Reactions\Model\ReactionAggregate',
+            'on' => "Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'",
+        ],
+    ],
     'sortby' => 'Aggregate.trending_score',
     'sortdir' => 'DESC',
     'limit' => 8,
@@ -149,7 +186,7 @@ title: Интеграция с pdoTools
 [[!pdoPage?
     &element=`pdoResources`
     &parents=`0`
-    &leftJoin=`{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
+    &leftJoin=`{"Aggregate":{"class":"Reactions\\\\Model\\\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
     &sortby=`Aggregate.likes`
     &sortdir=`DESC`
     &tpl=`tpl.article.card`
@@ -161,7 +198,12 @@ title: Интеграция с pdoTools
 {'!pdoPage' | snippet : [
     'element' => 'pdoResources',
     'parents' => 0,
-    'leftJoin' => '{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = \'modResource\'"}}',
+    'leftJoin' => [
+        'Aggregate' => [
+            'class' => 'Reactions\Model\ReactionAggregate',
+            'on' => "Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'",
+        ],
+    ],
     'sortby' => 'Aggregate.likes',
     'sortdir' => 'DESC',
     'tpl' => 'tpl.article.card',
@@ -206,7 +248,7 @@ title: Интеграция с pdoTools
 ```modx
 [[!pdoResources?
     &parents=`0`
-    &leftJoin=`{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
+    &leftJoin=`{"Aggregate":{"class":"Reactions\\\\Model\\\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
     &where=`{"Aggregate.likes:>":0}`
     &sortby=`Aggregate.likes`
     &sortdir=`DESC`
@@ -216,7 +258,12 @@ title: Интеграция с pdoTools
 ```fenom
 {'!pdoResources' | snippet : [
     'parents' => 0,
-    'leftJoin' => '{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = \'modResource\'"}}',
+    'leftJoin' => [
+        'Aggregate' => [
+            'class' => 'Reactions\Model\ReactionAggregate',
+            'on' => "Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'",
+        ],
+    ],
     'where' => '{"Aggregate.likes:>":0}',
     'sortby' => 'Aggregate.likes',
     'sortdir' => 'DESC',

--- a/docs/components/reactions/js.md
+++ b/docs/components/reactions/js.md
@@ -137,7 +137,9 @@ Reactions.init(container);
 
 Сервер считает режим exclusive, если набор `exclusive` **или** выключен `reactions_allow_multiple`. Сниппет пишет это в `data-exclusive` / `data-allow-multiple`. Виджет зеркалит ту же логику: при exclusive другая кнопка снимает предыдущую (optimistic UI).
 
-Несколько виджетов на один объект (`class_key` + `object_id` + `context`) синхронизируются событием `reactions:updated` на `document` после успешного POST/DELETE.
+Несколько виджетов на один объект (`class_key` + `object_id` + `context`) синхронизируются событием `reactions:updated` на `window` после успешного POST/DELETE.
+
+То же событие обновляет соседние `.reactions-count` (вывод сниппета `ReactionsCount`) с тем же объектом — без F5.
 
 ## Layout: bar и picker
 

--- a/docs/components/reactions/snippets/reactions-count.md
+++ b/docs/components/reactions/snippets/reactions-count.md
@@ -28,6 +28,20 @@ title: Сниппет ReactionsCount
 | `{PCT_DOWN}` | Доля дизлайков от общего, 0–100 |
 | `{like}`, `{love}`, `{funny}`… | Счётчик типа. Нет данных → `0`, не сырой `{love}` |
 
+## Live-обновление
+
+Сниппет оборачивает текст в:
+
+```html
+<span class="reactions-count"
+  data-class-key="…"
+  data-object-id="…"
+  data-context="…"
+  data-format="👍 {LIKES} · Σ {TOTAL}">…</span>
+```
+
+При клике по виджету Reactions на том же объекте (`class` + `object` + `context`) JS пересчитывает строку по `data-format` (событие `reactions:updated`). Нужен подключённый `reactions.js`.
+
 ## Примеры
 
 ### По умолчанию: только `{TOTAL}`

--- a/docs/en/components/reactions/integrations/collections.md
+++ b/docs/en/components/reactions/integrations/collections.md
@@ -55,7 +55,7 @@ Use pdoResources with a `leftJoin` on `ReactionAggregate`.
 [[!pdoResources?
     &parents=`[[*id]]`
     &depth=`1`
-    &leftJoin=`{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
+    &leftJoin=`{"Aggregate":{"class":"Reactions\\\\Model\\\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
     &sortby=`Aggregate.likes`
     &sortdir=`DESC`
     &tpl=`@INLINE <li><a href="[[+uri]]">[[+pagetitle]]</a> — [[!ReactionsCount? &object=`[[+id]]` &format=`{LIKES}`]]</li>`
@@ -66,7 +66,12 @@ Use pdoResources with a `leftJoin` on `ReactionAggregate`.
 {'!pdoResources' | snippet : [
     'parents' => $_modx->resource.id,
     'depth' => 1,
-    'leftJoin' => '{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = \'modResource\'"}}',
+    'leftJoin' => [
+        'Aggregate' => [
+            'class' => 'Reactions\Model\ReactionAggregate',
+            'on' => "Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'",
+        ],
+    ],
     'sortby' => 'Aggregate.likes',
     'sortdir' => 'DESC',
     'tpl' => '@INLINE <li><a href="[[+uri]]">[[+pagetitle]]</a> — [[!ReactionsCount? &object=`[[+id]]` &format=`{LIKES}`]]</li>',
@@ -116,7 +121,7 @@ On a “Popular in this section” page:
 [[!pdoResources?
     &parents=`[[*id]]`
     &depth=`2`
-    &leftJoin=`{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
+    &leftJoin=`{"Aggregate":{"class":"Reactions\\\\Model\\\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
     &sortby=`Aggregate.trending_score`
     &sortdir=`DESC`
     &limit=`6`
@@ -129,7 +134,12 @@ On a “Popular in this section” page:
 {'!pdoResources' | snippet : [
     'parents' => $_modx->resource.id,
     'depth' => 2,
-    'leftJoin' => '{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = \'modResource\'"}}',
+    'leftJoin' => [
+        'Aggregate' => [
+            'class' => 'Reactions\Model\ReactionAggregate',
+            'on' => "Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'",
+        ],
+    ],
     'sortby' => 'Aggregate.trending_score',
     'sortdir' => 'DESC',
     'limit' => 6,

--- a/docs/en/components/reactions/integrations/minishop3.md
+++ b/docs/en/components/reactions/integrations/minishop3.md
@@ -79,7 +79,7 @@ Aggregates store `object_class` as `msProduct` (whatever you passed in `class` /
 
 ## Sort the catalog by popularity
 
-Use `msProducts` with `leftJoin`.
+Use `msProducts` with `leftJoin`. Because msProducts uses `GROUP BY msProduct.id`, sort with `MAX(Aggregate.likes)`, not `Aggregate.likes` (see [pdoTools](pdotools)).
 
 ::: code-group
 
@@ -87,19 +87,25 @@ Use `msProducts` with `leftJoin`.
 [[!msProducts?
     &parents=`10`
     &limit=`12`
-    &leftJoin=`{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = msProduct.id AND Aggregate.object_class = 'msProduct'"}}`
-    &sortby=`Aggregate.likes`
+    &leftJoin=`{"Aggregate":{"class":"Reactions\\\\Model\\\\ReactionAggregate","on":"Aggregate.object_id = msProduct.id AND Aggregate.object_class = 'msProduct'"}}`
+    &sortby=`MAX(Aggregate.likes)`
     &sortdir=`DESC`
     &tpl=`tpl.msProduct.card`
 ]]
 ```
 
 ```fenom
+{set $rxProductJoin = [
+    'Aggregate' => [
+        'class' => 'Reactions\Model\ReactionAggregate',
+        'on' => "Aggregate.object_id = msProduct.id AND Aggregate.object_class = 'msProduct'",
+    ],
+]}
 {'!msProducts' | snippet : [
     'parents' => 10,
     'limit' => 12,
-    'leftJoin' => '{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = msProduct.id AND Aggregate.object_class = \'msProduct\'"}}',
-    'sortby' => 'Aggregate.likes',
+    'leftJoin' => $rxProductJoin,
+    'sortby' => 'MAX(Aggregate.likes)',
     'sortdir' => 'DESC',
     'tpl' => 'tpl.msProduct.card',
 ]}

--- a/docs/en/components/reactions/integrations/pdotools.md
+++ b/docs/en/components/reactions/integrations/pdotools.md
@@ -5,6 +5,28 @@ title: pdoTools integration
 
 Sort and list resources, products, and other objects by reactions with a `leftJoin` on the `ReactionAggregate` model.
 
+## leftJoin: JSON and Fenom
+
+pdoTools accepts `leftJoin` as an **array** or a JSON string. In JSON, escape the model class as `"Reactions\\Model\\ReactionAggregate"` (two `\` characters before `Model` in the final string).
+
+| Approach | Example |
+| --- | --- |
+| MODX tag | `"class":"Reactions\\\\Model\\\\ReactionAggregate"` — **four** `\` in the template, two remain in JSON |
+| Fenom | array `'class' => 'Reactions\Model\ReactionAggregate'` — preferred, no JSON |
+| PHP / snippet | `'class' => ReactionAggregate::class` or a join array |
+
+If the JSON is invalid, `json_decode` in msProducts/pdoResources silently skips the join. Then the log shows:
+
+`Unknown column 'Aggregate.likes' in 'order clause'`
+
+### msProducts and ONLY_FULL_GROUP_BY
+
+`msProducts` always groups by `msProduct.id`. On MySQL with `ONLY_FULL_GROUP_BY` you cannot sort by plain `Aggregate.likes` — use an aggregate:
+
+`&sortby=`MAX(Aggregate.likes)`` or `'sortby' => 'MAX(Aggregate.likes)'`
+
+For `pdoResources` without `GROUP BY`, `Aggregate.likes` is enough.
+
 ## ReactionAggregate model
 
 The `reactions_aggregates` table stores precomputed metrics:
@@ -30,7 +52,7 @@ The `reactions_aggregates` table stores precomputed metrics:
     &parents=`0`
     &depth=`10`
     &limit=`12`
-    &leftJoin=`{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource' AND Aggregate.context = 'web'"}}`
+    &leftJoin=`{"Aggregate":{"class":"Reactions\\\\Model\\\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource' AND Aggregate.context = 'web'"}}`
     &sortby=`Aggregate.likes`
     &sortdir=`DESC`
     &tpl=`tpl.article.card`
@@ -42,7 +64,12 @@ The `reactions_aggregates` table stores precomputed metrics:
     'parents' => 0,
     'depth' => 10,
     'limit' => 12,
-    'leftJoin' => '{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = \'modResource\' AND Aggregate.context = \'web\'"}}',
+    'leftJoin' => [
+        'Aggregate' => [
+            'class' => 'Reactions\Model\ReactionAggregate',
+            'on' => "Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource' AND Aggregate.context = 'web'",
+        ],
+    ],
     'sortby' => 'Aggregate.likes',
     'sortdir' => 'DESC',
     'tpl' => 'tpl.article.card',
@@ -58,7 +85,7 @@ The `reactions_aggregates` table stores precomputed metrics:
 ```modx
 [[!pdoResources?
     &parents=`5`
-    &leftJoin=`{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
+    &leftJoin=`{"Aggregate":{"class":"Reactions\\\\Model\\\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
     &sortby=`Aggregate.rating`
     &sortdir=`DESC`
     &limit=`10`
@@ -68,7 +95,12 @@ The `reactions_aggregates` table stores precomputed metrics:
 ```fenom
 {'!pdoResources' | snippet : [
     'parents' => 5,
-    'leftJoin' => '{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = \'modResource\'"}}',
+    'leftJoin' => [
+        'Aggregate' => [
+            'class' => 'Reactions\Model\ReactionAggregate',
+            'on' => "Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'",
+        ],
+    ],
     'sortby' => 'Aggregate.rating',
     'sortdir' => 'DESC',
     'limit' => 10,
@@ -84,7 +116,7 @@ The `reactions_aggregates` table stores precomputed metrics:
 ```modx
 [[!pdoResources?
     &parents=`0`
-    &leftJoin=`{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
+    &leftJoin=`{"Aggregate":{"class":"Reactions\\\\Model\\\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
     &sortby=`Aggregate.trending_score`
     &sortdir=`DESC`
     &limit=`8`
@@ -94,7 +126,12 @@ The `reactions_aggregates` table stores precomputed metrics:
 ```fenom
 {'!pdoResources' | snippet : [
     'parents' => 0,
-    'leftJoin' => '{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = \'modResource\'"}}',
+    'leftJoin' => [
+        'Aggregate' => [
+            'class' => 'Reactions\Model\ReactionAggregate',
+            'on' => "Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'",
+        ],
+    ],
     'sortby' => 'Aggregate.trending_score',
     'sortdir' => 'DESC',
     'limit' => 8,
@@ -149,7 +186,7 @@ Or via a placeholder:
 [[!pdoPage?
     &element=`pdoResources`
     &parents=`0`
-    &leftJoin=`{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
+    &leftJoin=`{"Aggregate":{"class":"Reactions\\\\Model\\\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
     &sortby=`Aggregate.likes`
     &sortdir=`DESC`
     &tpl=`tpl.article.card`
@@ -161,7 +198,12 @@ Or via a placeholder:
 {'!pdoPage' | snippet : [
     'element' => 'pdoResources',
     'parents' => 0,
-    'leftJoin' => '{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = \'modResource\'"}}',
+    'leftJoin' => [
+        'Aggregate' => [
+            'class' => 'Reactions\Model\ReactionAggregate',
+            'on' => "Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'",
+        ],
+    ],
     'sortby' => 'Aggregate.likes',
     'sortdir' => 'DESC',
     'tpl' => 'tpl.article.card',
@@ -206,7 +248,7 @@ In a list row template (chunk `tpl` / `$results` loop):
 ```modx
 [[!pdoResources?
     &parents=`0`
-    &leftJoin=`{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
+    &leftJoin=`{"Aggregate":{"class":"Reactions\\\\Model\\\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'"}}`
     &where=`{"Aggregate.likes:>":0}`
     &sortby=`Aggregate.likes`
     &sortdir=`DESC`
@@ -216,7 +258,12 @@ In a list row template (chunk `tpl` / `$results` loop):
 ```fenom
 {'!pdoResources' | snippet : [
     'parents' => 0,
-    'leftJoin' => '{"Aggregate":{"class":"Reactions\\Model\\ReactionAggregate","on":"Aggregate.object_id = modResource.id AND Aggregate.object_class = \'modResource\'"}}',
+    'leftJoin' => [
+        'Aggregate' => [
+            'class' => 'Reactions\Model\ReactionAggregate',
+            'on' => "Aggregate.object_id = modResource.id AND Aggregate.object_class = 'modResource'",
+        ],
+    ],
     'where' => '{"Aggregate.likes:>":0}',
     'sortby' => 'Aggregate.likes',
     'sortdir' => 'DESC',

--- a/docs/en/components/reactions/js.md
+++ b/docs/en/components/reactions/js.md
@@ -138,7 +138,9 @@ For custom sets, server validation still works through the API, but JS renders b
 
 The server treats the mode as exclusive when the set is `exclusive` **or** `reactions_allow_multiple` is off. The snippet writes this into `data-exclusive` / `data-allow-multiple`. The widget mirrors the same logic: under exclusive, another button clears the previous one (optimistic UI).
 
-Several widgets for the same object (`class_key` + `object_id` + `context`) sync via the `reactions:updated` event on `document` after a successful POST/DELETE.
+Several widgets for the same object (`class_key` + `object_id` + `context`) sync via the `reactions:updated` event on `window` after a successful POST/DELETE.
+
+The same event updates sibling `.reactions-count` nodes (`ReactionsCount` snippet) for that object — no page reload.
 
 ## Layout: bar and picker
 

--- a/docs/en/components/reactions/snippets/reactions-count.md
+++ b/docs/en/components/reactions/snippets/reactions-count.md
@@ -28,6 +28,20 @@ Text counters without buttons, for cards, lists, and meta rows.
 | `{PCT_DOWN}` | Dislike share of the total, 0–100 |
 | `{like}`, `{love}`, `{funny}`… | Count for that type. No data → `0`, not a raw `{love}` |
 
+## Live updates
+
+The snippet wraps the text in:
+
+```html
+<span class="reactions-count"
+  data-class-key="…"
+  data-object-id="…"
+  data-context="…"
+  data-format="👍 {LIKES} · Σ {TOTAL}">…</span>
+```
+
+When you click the Reactions widget for the same object (`class` + `object` + `context`), JS recalculates the string from `data-format` (`reactions:updated` event). Requires `reactions.js` on the page.
+
 ## Examples
 
 ### Default: `{TOTAL}` only


### PR DESCRIPTION
Синхронизация документации Reactions с пакетом [modx-pro/Reactions](https://github.com/modx-pro/Reactions) 1.0.1.

В 1.0.1 появилось live-обновление `ReactionsCount` рядом с виджетом (`span.reactions-count` + `reactions:updated` на `window`) и уточнения по `leftJoin`: четыре `\` в MODX-JSON, массив в Fenom, `MAX(Aggregate.likes)` для `msProducts` при `ONLY_FULL_GROUP_BY`.

Обновлены RU/EN: `reactions-count`, `js`, `pdotools`, `minishop3`, `collections`.