### PR TITLE
docs(sendit): show reset password on activation page

### DIFF
--- a/docs/components/sendit/identification.md
+++ b/docs/components/sendit/identification.md
@@ -301,6 +301,25 @@
 
 Комбинация этих параметров позволяет после восстановления пароля сразу авторизовать пользователя и отправить на любую страницу сайта.
 
+Чтобы показать новый пароль на странице активации, сохраните результат вызова **PasswordReset** без кэша в переменную и выведите поле `extended.temp_password`.
+Если включён редирект через `afterLoginRedirectId`, пользователь сразу уйдёт на другую страницу и не увидит этот блок.
+
+::: details Страница активации
+
+```fenom:line-numbers
+{set $resetResult = '!PasswordReset' | snippet: []}
+
+{if $resetResult}
+  <p>Пароль изменён.</p>
+
+  {if $resetResult.extended.temp_password}
+    <p>Новый пароль: <strong>{$resetResult.extended.temp_password}</strong></p>
+  {/if}
+{/if}
+```
+
+:::
+
 ::: details Форма
 
 ```html:line-numbers

--- a/docs/components/sendit/snippets.md
+++ b/docs/components/sendit/snippets.md
@@ -154,6 +154,20 @@
 {'!PasswordReset' | snippet: []}
 ```
 
+Чтобы показать новый пароль пользователю на странице активации:
+
+```fenom:line-numbers
+{set $resetResult = '!PasswordReset' | snippet: []}
+
+{if $resetResult}
+  <p>Пароль изменён.</p>
+
+  {if $resetResult.extended.temp_password}
+    <p>Новый пароль: <strong>{$resetResult.extended.temp_password}</strong></p>
+  {/if}
+{/if}
+```
+
 ## Pagination
 
 ### Назначение


### PR DESCRIPTION
Добавляет публичный пример для SendIt PasswordReset: как сохранить результат вызова без кэша и вывести новый временный пароль из extended.temp_password на странице activationResourceId.

Проверено:
- markdownlint для docs/components/sendit/identification.md и docs/components/sendit/snippets.md
- git diff --check

Cspell по этим двум файлам сохраняет существующие словарные предупреждения, новых по добавленному блоку нет.