### PR TITLE
fix(minishop3): dead link msp3sberbank в EN payments

### DIFF
--- a/docs/en/components/minishop3/interface/settings/payments.md
+++ b/docs/en/components/minishop3/interface/settings/payments.md
@@ -10,7 +10,7 @@ Managed via **Extras → MiniShop3 → Settings → Payments**.
 1. Create a payment method: name, description, logo, active flag.
 2. Link it to the needed [deliveries](/en/components/minishop3/interface/settings/deliveries). Without a link the customer cannot pick the pair on the storefront.
 3. For pay-on-delivery leave the `class` field empty. The order simply stores the selected `payment_id`.
-4. For online payment install a payment extra from the catalog (for example [msp3YooKassa](/en/components/msp3yookassa/), [mspTBank](/en/components/msptbank/), [msp3Sberbank](/en/components/msp3sberbank/)) and set the handler class in `class` as in that package's docs.
+4. For online payment install a payment extra from the catalog (for example [msp3YooKassa](/en/components/msp3yookassa/), [mspTBank](/en/components/msptbank/), [msp3Sberbank](/components/msp3sberbank/)) and set the handler class in `class` as in that package's docs.
 5. Check the post-payment redirect: `ms3_order_success_page_id` and the Thanks page with `msGetOrder`.
 
 Surcharge in the `price` field:


### PR DESCRIPTION
## Summary
- Деплой после #999 падал: dead link `/en/components/msp3sberbank/index` в `docs/en/components/minishop3/interface/settings/payments.md` ([run](https://github.com/modx-pro/Docs/actions/runs/31477891187/job/93735791906)).
- EN-папки `msp3sberbank` нет — ссылка переведена на существующую RU-документацию `/components/msp3sberbank/`.

## Test plan
- [ ] CI Deploy / `pnpm build` без dead links